### PR TITLE
Feature/logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@flow-engine/core": "^0.2.1",
     "axios": "^0.26.1",
+    "pino": "^8.0.0",
+    "pino-std-serializers": "^6.0.0",
     "typescript": "^4.6.2"
   },
   "devDependencies": {

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -1,7 +1,13 @@
 import { Flow, FlowInput } from '@flow-engine/core';
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { Logger } from 'pino';
 
-type HTTPFlowInput<Input = FlowInput, Body = any> = Input & { axiosConfig?: AxiosRequestConfig<Body> };
+import fulfilledRequest from './logInterceptor/fulfilledRequest';
+import rejectedRequest from './logInterceptor/rejectedRequest';
+import fulfilledResponse from './logInterceptor/fulfilledResponse';
+import rejectedResponse from './logInterceptor/rejectedResponse';
+
+type HTTPFlowInput<Input = FlowInput, Body = any> = Input & { axiosConfig: InternalAxiosRequestConfig<Body>, logger?: Logger };
 type HTTPFlowOutput<Input = FlowInput, Body = any> = Input & { response: AxiosResponse<Body> };
 type HTTPFlow<
     Input = FlowInput,
@@ -9,21 +15,29 @@ type HTTPFlow<
     BodyOutput = any,
 > = Flow<HTTPFlowInput<Input, BodyInput>, HTTPFlowOutput<Input, BodyOutput>> & { instance: AxiosInstance };
 
+export interface InternalAxiosRequestConfig<Body = any> extends AxiosRequestConfig<Body> {
+    logger?: Logger,
+}
+
 const httpClient = <
     Input extends FlowInput = FlowInput,
     BodyInput extends any = any,
     BodyOutput extends any = any,
     Config extends AxiosRequestConfig = AxiosRequestConfig,
->(config: Config): HTTPFlow<Input, BodyInput, BodyOutput> => {
+>(config: Config, logger?: Logger): HTTPFlow<Input, BodyInput, BodyOutput> => {
     const instance = axios.create(config);
 
-    const httpClientFlow: HTTPFlow<Input, BodyInput, BodyOutput> = (input: HTTPFlowInput<Input, BodyInput>): Promise<HTTPFlowOutput<Input, BodyOutput>> => {
-        return instance.request<BodyOutput>(input.axiosConfig || config).then((response: AxiosResponse<BodyOutput>) => {
-            const output = { ...input, response };
-            delete output.axiosConfig;
+    instance.interceptors.request.use(fulfilledRequest, rejectedRequest);
+    instance.interceptors.response.use(fulfilledResponse, rejectedResponse);
 
-            return output;
-        });
+    const httpClientFlow: HTTPFlow<Input, BodyInput, BodyOutput> = (input: HTTPFlowInput<Input, BodyInput>): Promise<HTTPFlowOutput<Input, BodyOutput>> => {
+        return instance.request<BodyOutput>({ ...input.axiosConfig, logger: input.logger || logger } as InternalAxiosRequestConfig)
+            .then((response: AxiosResponse<BodyOutput>): HTTPFlowOutput<Input, BodyOutput> => {
+                const output = { ...input, response } as HTTPFlowOutput<Input, BodyOutput> & { axiosConfig?: AxiosRequestConfig };
+                delete output.axiosConfig;
+    
+                return output;
+            });
     };
 
     httpClientFlow.id = 'httpClientFlow';

--- a/src/logInterceptor/fulfilledRequest.ts
+++ b/src/logInterceptor/fulfilledRequest.ts
@@ -1,0 +1,39 @@
+import { InternalAxiosRequestConfig } from '../httpClient';
+
+const buildFullPath = require('axios/lib/core/buildFullPath');
+const buildURL = require('axios/lib/helpers/buildURL');
+
+/*
+* TODO: to remove
+* This function is temporary, since the fix for instance.getUri is not tagged on axios repository:
+* https://github.com/axios/axios/pull/3737
+*/
+const getUri = (config: InternalAxiosRequestConfig): string => {
+    const fullPath: string = buildFullPath(config.baseURL, config.url);
+    return buildURL(fullPath, config.params, config.paramsSerializer);
+};
+
+interface LogContext {
+    url: string,
+    method: string,
+    body?: string,
+}
+
+export default (requestConfig: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+    if (typeof requestConfig.logger === 'undefined') {
+        return requestConfig;
+    }
+
+    const context: LogContext = {
+        url: getUri(requestConfig),
+        method: requestConfig.method || 'GET',
+    };
+
+    if (typeof requestConfig.data !== 'undefined') {
+        context.body = JSON.stringify(requestConfig.data);
+    }
+
+    requestConfig.logger.info(context, 'http:request');
+
+    return requestConfig;
+};

--- a/src/logInterceptor/fulfilledResponse.ts
+++ b/src/logInterceptor/fulfilledResponse.ts
@@ -1,0 +1,20 @@
+import { AxiosResponse } from 'axios';
+import { InternalAxiosRequestConfig } from '../httpClient';
+
+export default (response: AxiosResponse): AxiosResponse => {
+    const requestConfig: InternalAxiosRequestConfig = response.config;
+
+    if (typeof requestConfig.logger === 'undefined') {
+        return response;
+    }
+
+    const context = {
+        headers: JSON.stringify(response.headers),
+        body: JSON.stringify(response.data),
+        http_code: response.status,
+    };
+
+    requestConfig.logger.info(context, 'http:response');
+
+    return response;
+};

--- a/src/logInterceptor/rejectedRequest.ts
+++ b/src/logInterceptor/rejectedRequest.ts
@@ -1,0 +1,25 @@
+import { err } from 'pino-std-serializers';
+import { AxiosError } from 'axios';
+import { InternalAxiosRequestConfig } from '../httpClient';
+
+export default (error: AxiosError | any): Promise<AxiosError | any> => {
+    if (!error.isAxiosError) {
+        return Promise.reject(error);
+    }
+
+    const config: InternalAxiosRequestConfig = error.config;
+
+    if (typeof config.logger === 'undefined') {
+        return Promise.reject(error);
+    }
+
+    const serializedError = err(error);
+    delete serializedError.config;
+
+    config.logger.error(
+        { error: JSON.stringify(serializedError) },
+        'http:request:error',
+    );
+
+    return Promise.reject(error);
+};

--- a/src/logInterceptor/rejectedResponse.ts
+++ b/src/logInterceptor/rejectedResponse.ts
@@ -1,0 +1,30 @@
+import { err } from 'pino-std-serializers';
+import { AxiosError } from 'axios';
+import { InternalAxiosRequestConfig } from '../httpClient';
+
+export default (error: AxiosError | any): Promise<AxiosError | any> => {
+    if (!error.isAxiosError) {
+        return Promise.reject(error);
+    }
+
+    const config: InternalAxiosRequestConfig = error.config;
+
+    if (typeof config.logger === 'undefined') {
+        return Promise.reject(error);
+    }
+
+    const serializedError = err(error);
+    delete serializedError.config;
+
+    config.logger.error(
+        {
+            error: JSON.stringify(serializedError),
+            http_code: error.response?.status || -1,
+            body: JSON.stringify(error.response?.data),
+            headers: JSON.stringify(error.response?.headers),
+        },
+        'http:response:error',
+    );
+
+    return Promise.reject(error);
+};

--- a/test/functional/httpClient.test.ts
+++ b/test/functional/httpClient.test.ts
@@ -1,5 +1,7 @@
 import MockAdapter from 'axios-mock-adapter';
+import pino from 'pino';
 import { httpClient } from '../../src';
+import { AxiosRequestConfig } from 'axios';
 
 describe('Test httpClient flow', () => {
     test('HTTP request fail - route not found', async () => {
@@ -21,18 +23,6 @@ describe('Test httpClient flow', () => {
         axiosMock.onGet('/api/test/1').reply(200, { value: 1 });
 
         const { response } = await flow({ axiosConfig: { url: '/api/test/1', method: 'GET' } });
-
-        expect(response.status).toStrictEqual(200);
-        expect(response.data).toStrictEqual({ value: 1 });
-    });
-
-    test('GET success - without axiosConfig attribute', async () => {
-        const flow = httpClient<{}, { value: number }>({ url: '/api/test/1', method: 'GET' });
-        const axiosMock = new MockAdapter(flow.instance);
-
-        axiosMock.onGet('/api/test/1').reply(200, { value: 1 });
-
-        const { response } = await flow({});
 
         expect(response.status).toStrictEqual(200);
         expect(response.data).toStrictEqual({ value: 1 });
@@ -90,5 +80,223 @@ describe('Test httpClient flow', () => {
 
         expect(response.status).toStrictEqual(200);
         expect(response.data).toStrictEqual({ value: 5 });
+    });
+
+    test('GET success with global logger', async () => {
+        const logger = pino();
+        logger.info = jest.fn();
+
+        const flow = httpClient<{}, { value: number }>({}, logger);
+        const axiosMock = new MockAdapter(flow.instance);
+
+        axiosMock.onGet('/api/test/1').reply(200, { value: 1 });
+
+        const { response } = await flow({ axiosConfig: { url: '/api/test/1', method: 'GET' } });
+
+        expect(response.status).toStrictEqual(200);
+        expect(response.data).toStrictEqual({ value: 1 });
+
+        const infoLogMock = logger.info as jest.Mock;
+        expect(infoLogMock.mock.calls.length).toStrictEqual(2);
+        expect(infoLogMock.mock.calls[0][0]).toStrictEqual({ method: 'get', url: '/api/test/1' });
+        expect(infoLogMock.mock.calls[0][1]).toStrictEqual('http:request');
+        expect(infoLogMock.mock.calls[1][0]).toStrictEqual({ body: '{"value":1}', headers: undefined, http_code: 200 });
+        expect(infoLogMock.mock.calls[1][1]).toStrictEqual('http:response');
+    });
+
+    test('GET network error with global logger', async () => {
+        const logger = pino();
+        logger.info = jest.fn();
+        logger.error = jest.fn();
+
+        const flow = httpClient<{}, { value: number }>({}, logger);
+        const axiosMock = new MockAdapter(flow.instance);
+
+        axiosMock.onGet('/api/test/1').networkErrorOnce();
+
+        await expect(flow({ axiosConfig: { url: '/api/test/1', method: 'GET' } })).rejects.toMatchObject({
+            isAxiosError: true,
+        });
+
+        const infoLogMock = logger.info as jest.Mock;
+        expect(infoLogMock.mock.calls.length).toStrictEqual(1);
+        expect(infoLogMock.mock.calls[0][0]).toStrictEqual({ method: 'get', url: '/api/test/1' });
+        expect(infoLogMock.mock.calls[0][1]).toStrictEqual('http:request');
+
+        const errorLogMock = logger.error as jest.Mock;
+        expect(errorLogMock.mock.calls.length).toStrictEqual(1);
+        expect(errorLogMock.mock.calls[0][0]).toMatchObject({
+            body: undefined,
+            headers: undefined,
+            http_code: -1,
+            error: expect.stringMatching('Network Error'),
+        });
+        expect(errorLogMock.mock.calls[0][1]).toStrictEqual('http:response:error');
+    });
+
+    test('GET request interceptor throw not AxiosError with global logger - impossible to log', async () => {
+        const logger = pino();
+        logger.info = jest.fn();
+        logger.error = jest.fn();
+
+        const flow = httpClient<{}, { value: number }>({}, logger);
+        flow.instance.interceptors.request.use(() => {
+            throw new Error('toto');
+        });
+
+        const axiosMock = new MockAdapter(flow.instance);
+
+        axiosMock.onGet('/api/test/1').networkErrorOnce();
+
+        await expect(flow({ axiosConfig: { url: '/api/test/1', method: 'GET' } })).rejects.toMatchObject({
+            message: 'toto',
+        });
+
+        const infoLogMock = logger.info as jest.Mock;
+        expect(infoLogMock.mock.calls.length).toStrictEqual(0);
+
+        const errorLogMock = logger.error as jest.Mock;
+        expect(errorLogMock.mock.calls.length).toStrictEqual(0);
+    });
+
+    test('GET request interceptor throw AxiosError with global logger', async () => {
+        const logger = pino();
+        logger.info = jest.fn();
+        logger.error = jest.fn();
+
+        const flow = httpClient<{}, { value: number }>({}, logger);
+        flow.instance.interceptors.request.use((config: AxiosRequestConfig) => {
+            const error: any = new Error('toto');
+
+            Object.defineProperties(error, {
+                isAxiosError: { value: true },
+                config: { value: config },
+            });
+
+            throw error;
+        });
+
+        const axiosMock = new MockAdapter(flow.instance);
+
+        axiosMock.onGet('/api/test/1').networkErrorOnce();
+
+        await expect(flow({ axiosConfig: { url: '/api/test/1', method: 'GET' } })).rejects.toMatchObject({
+            message: 'toto',
+        });
+
+        const infoLogMock = logger.info as jest.Mock;
+        expect(infoLogMock.mock.calls.length).toStrictEqual(0);
+
+        const errorLogMock = logger.error as jest.Mock;
+        expect(errorLogMock.mock.calls.length).toStrictEqual(2);
+
+        expect(errorLogMock.mock.calls[0][0]).toMatchObject({
+            error: expect.stringContaining('toto'),
+        });
+        expect(errorLogMock.mock.calls[0][1]).toStrictEqual('http:request:error');
+
+        expect(errorLogMock.mock.calls[1][0]).toMatchObject({
+            body: undefined,
+            headers: undefined,
+            http_code: -1,
+            error: expect.stringContaining('toto'),
+        });
+        expect(errorLogMock.mock.calls[1][1]).toStrictEqual('http:response:error');
+    });
+
+    test('POST success with global logger', async () => {
+        const logger = pino();
+        logger.info = jest.fn();
+
+        const flow = httpClient<{}, { value: number }>({}, logger);
+        const axiosMock = new MockAdapter(flow.instance);
+
+        axiosMock.onPost('/api/test', { value: 2 }).reply(201, { value: 2 });
+
+        const { response } = await flow({ axiosConfig: { url: '/api/test', method: 'POST', data: { value: 2 } } });
+
+        expect(response.status).toStrictEqual(201);
+        expect(response.data).toStrictEqual({ value: 2 });
+
+        const infoLogMock = logger.info as jest.Mock;
+        expect(infoLogMock.mock.calls.length).toStrictEqual(2);
+        expect(infoLogMock.mock.calls[0][0]).toStrictEqual({ method: 'post', url: '/api/test', body: '{"value":2}'  });
+        expect(infoLogMock.mock.calls[0][1]).toStrictEqual('http:request');
+        expect(infoLogMock.mock.calls[1][0]).toStrictEqual({ body: '{"value":2}', headers: undefined, http_code: 201 });
+        expect(infoLogMock.mock.calls[1][1]).toStrictEqual('http:response');
+    });
+
+    test('HTTP request fail - route not found with logger 2 ways', async () => {
+        {
+            const logger = pino();
+            logger.info = jest.fn();
+            logger.error = jest.fn();
+
+            const flow = httpClient<{}, { value: number }>({}, logger);
+            const axiosMock = new MockAdapter(flow.instance);
+
+            axiosMock.onGet('/api/test/1').reply(200, { value: 1 });
+
+            await expect(flow({ axiosConfig: { url: '/api/not-found' } })).rejects.toMatchObject({
+                isAxiosError: true,
+                response: expect.objectContaining({ status: 404 }),
+            });
+
+            const infoLogMock = logger.info as jest.Mock;
+            expect(infoLogMock.mock.calls.length).toStrictEqual(1);
+            expect(infoLogMock.mock.calls[0][0]).toStrictEqual({ method: 'get', url: '/api/not-found' });
+            expect(infoLogMock.mock.calls[0][1]).toStrictEqual('http:request');
+
+            const errorLogMock = logger.error as jest.Mock;
+            expect(errorLogMock.mock.calls.length).toStrictEqual(1);
+            expect(errorLogMock.mock.calls[0][0]).toMatchObject({
+                body: undefined,
+                headers: undefined,
+                http_code: 404,
+                error: expect.stringContaining('Request failed with status code 404'),
+            });
+            expect(errorLogMock.mock.calls[0][1]).toStrictEqual('http:response:error');
+        }
+
+        {
+            const logger = pino();
+            const logger2 = logger.child({ value2: 'test' });
+            logger.info = jest.fn();
+            logger.error = jest.fn();
+            logger2.info = jest.fn();
+            logger2.error = jest.fn();
+
+            const flow = httpClient<{}, { value: number }>({}, logger);
+            const axiosMock = new MockAdapter(flow.instance);
+
+            axiosMock.onGet('/api/test/1').reply(200, { value: 1 });
+
+            await expect(flow({ axiosConfig: { url: '/api/not-found' }, logger: logger2 })).rejects.toMatchObject({
+                isAxiosError: true,
+                response: expect.objectContaining({ status: 404 }),
+            });
+
+            const infoLogMock = logger.info as jest.Mock;
+            const errorLogMock = logger.error as jest.Mock;
+
+            expect(infoLogMock.mock.calls.length).toStrictEqual(0);
+            expect(errorLogMock.mock.calls.length).toStrictEqual(0);
+
+            const infoLogMock2 = logger2.info as jest.Mock;
+            const errorLogMock2 = logger2.error as jest.Mock;
+
+            expect(infoLogMock2.mock.calls.length).toStrictEqual(1);
+            expect(infoLogMock2.mock.calls[0][0]).toStrictEqual({ method: 'get', url: '/api/not-found' });
+            expect(infoLogMock2.mock.calls[0][1]).toStrictEqual('http:request');
+
+            expect(errorLogMock2.mock.calls.length).toStrictEqual(1);
+            expect(errorLogMock2.mock.calls[0][0]).toMatchObject({
+                body: undefined,
+                headers: undefined,
+                http_code: 404,
+                error: expect.stringContaining('Request failed with status code 404'),
+            });
+            expect(errorLogMock2.mock.calls[0][1]).toStrictEqual('http:response:error');
+        }
     });
 });


### PR DESCRIPTION
- Allow httpCLient flow to take pino logger as config and/or input
- Add interceptors to log request and response's success and error if a logger is injected
- Sending an axiosConfig into input is now mandatory